### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,13 @@ name = "comfy-mecha"
 description = "Nodes:Blocks Mecha Hyper, Mecha Merger, Model Mecha Recipe, Custom Code Mecha Recipe"
 version = "1.0.0"
 license = "LICENSE"
-dependencies = ["sd-mecha>=0.0.7"]
+dependencies = ["sd-mecha>=0.0.14"]
 
 [project.urls]
 Repository = "https://github.com/ljleb/comfy-mecha"
 #  Used by Comfy Registry https://comfyregistry.org
 
 [tool.comfy]
-PublisherId = ""
-DisplayName = "comfy-mecha"
+PublisherId = "ljleb"
+DisplayName = "mecha"
 Icon = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfy-mecha"
-description = "Nodes:Blocks Mecha Hyper, Mecha Merger, Model Mecha Recipe, Custom Code Mecha Recipe"
+description = "model merging nodes powered by sd-mecha, a memory efficient state dict recipe merger"
 version = "1.0.0"
 license = "LICENSE"
 dependencies = ["sd-mecha>=0.0.14"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfy-mecha"
+description = "Nodes:Blocks Mecha Hyper, Mecha Merger, Model Mecha Recipe, Custom Code Mecha Recipe"
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["sd-mecha>=0.0.7"]
+
+[project.urls]
+Repository = "https://github.com/ljleb/comfy-mecha"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "comfy-mecha"
+Icon = ""


### PR DESCRIPTION
We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.

Here’s some [more information](https://www.comfydocs.org/registry/overview#introduction) on the registry.

Action Required:

- [x] Go to the [registry](https://www.comfyregistry.org/). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
- [x] Write a short the description.
- [ ] Merge the separate Github Actions PR and run the workflow.
If you want to publish the node manually, [install the cli](https://www.comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`


Please message me on [Discord](https://discord.com/invite/comfycontrib) if you have any questions!